### PR TITLE
fix: export chainlink-feeds from utils

### DIFF
--- a/packages/v1-core/src/utils/index.ts
+++ b/packages/v1-core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./shared-credit.js";
 export * from "./calculations.js";
 export * from "./utils.js";
+export * from "./chainlink-feeds.js";


### PR DESCRIPTION
Need to access `getFeedData` from the frontend to see if it is possible to create a chainlink proposal for a given set of assets